### PR TITLE
fix tempfile_size implementation

### DIFF
--- a/src/screen.C
+++ b/src/screen.C
@@ -97,12 +97,11 @@ tempfile_deref(tempfile_t *tempfile)
 static size_t
 tempfile_size(tempfile_t *tempfile)
 {
-  fpos_t fsize = 0;
+  struct stat info;
 
-  fseek((FILE *)tempfile->fp, 0L, SEEK_END);
-  fgetpos((FILE *)tempfile->fp, &fsize);
+  fstat(fileno(tempfile->fp), &info);
 
-  return (size_t)fsize;
+  return info.st_size;
 }
 
 static tempfile_t *


### PR DESCRIPTION
Using fpos_t allowed only within fgetpos/fsetpos functions. Direct using is not allowed.
Anyway this function does not compile with gcc (Gentoo 7.3.0 p1.0) 7.3.0.
-----
my rxvt-unicode after all patches https://imgur.com/a/q0JjT
tnx for the library and rxvt patch!